### PR TITLE
Bump Quarkus to 1.1.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.0.0.Final</quarkus.version>
+    <quarkus.version>1.1.0.Final</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
 
   </properties>

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
@@ -50,7 +50,7 @@ import javax.ws.rs.ext.Provider;
 public class IncomingRequestFilter implements ContainerRequestFilter {
 
   @Inject
-  private CPPrincipalProducer producer;
+  CPPrincipalProducer producer;
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {


### PR DESCRIPTION
  Get rid of a warning from Quarkus about access level

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>