### PR TITLE
Fixed openapi.json URL according to the standardized location

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.datasource.password = connor
 com.redhat.cloud.custompolicies.app.VerifyEngine/mp-rest/url=http://localhost:8083
 
 # OpenAPI path
-quarkus.smallrye-openapi.path=/api/custom-policies/v1.0/policies/openapi.json
+quarkus.smallrye-openapi.path=/api/custom-policies/v1.0/openapi.json


### PR DESCRIPTION
That seems to fix the openapi.json file to be served from the right URL