### PR TITLE
Produce a structured access log (goes to stdout).

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/JaxRsApplication.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/JaxRsApplication.java
@@ -16,6 +16,10 @@
  */
 package com.redhat.cloud.custompolicies.app;
 
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import javax.enterprise.event.Observes;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
@@ -25,4 +29,11 @@ import javax.ws.rs.core.Application;
  *
  */
 @ApplicationPath("/api/custom-policies/v1.0")
-public class JaxRsApplication extends Application { }
+public class JaxRsApplication extends Application {
+
+  // Produce access log
+  void observeRouter(@Observes Router router) {
+    Handler<RoutingContext> handler = new JsonAccessLoggerHandler();
+    router.route().order(-1000).handler(handler);
+  }
+}

--- a/src/main/java/com/redhat/cloud/custompolicies/app/JsonAccessLoggerHandler.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/JsonAccessLoggerHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.custompolicies.app;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerHandler;
+import io.vertx.ext.web.impl.Utils;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+/**
+ * @author hrupp
+ */
+public class JsonAccessLoggerHandler implements LoggerHandler {
+
+  Jsonb jsonb;
+  JsonObjectBuilder jsonObjectBuilder;
+
+
+  public JsonAccessLoggerHandler() {
+    jsonb = JsonbBuilder.create();
+    jsonObjectBuilder = Json.createObjectBuilder();
+  }
+
+
+  void log(RoutingContext context, long timestamp, String remoteClient, HttpVersion version, HttpMethod method, String uri) {
+
+    jsonObjectBuilder.add("date", Utils.formatRFC1123DateTime(timestamp));
+    jsonObjectBuilder.add("method",method.name());
+    jsonObjectBuilder.add("uri",uri);
+
+    HttpServerRequest request = context.request();
+    String versionFormatted ;
+    switch (version){
+      case HTTP_1_0:
+        versionFormatted = "HTTP/1.0";
+        break;
+      case HTTP_1_1:
+        versionFormatted = "HTTP/1.1";
+        break;
+      case HTTP_2:
+        versionFormatted = "HTTP/2.0";
+        break;
+      default:
+        versionFormatted = "-none-";
+    }
+    jsonObjectBuilder.add("http_version",versionFormatted);
+    long contentLength = request.response().bytesWritten();
+
+    int status = request.response().getStatusCode();
+    jsonObjectBuilder.add("status",status);
+    jsonObjectBuilder.add("content_length",contentLength);
+
+    jsonObjectBuilder.add("duration", System.currentTimeMillis()-timestamp);
+
+    final MultiMap headers = request.headers();
+    String referrer = headers.contains("referrer") ? headers.get("referrer") : headers.get("referer");
+    String userAgent = request.headers().get("user-agent");
+
+    if (referrer != null) {
+      jsonObjectBuilder.add("referrer", referrer);
+    }
+    if (userAgent != null) {
+      jsonObjectBuilder.add("user_agent", userAgent);
+    }
+    jsonObjectBuilder.add("remote",remoteClient);
+
+
+    JsonObject jsonMessage = jsonObjectBuilder.build();
+    String msg = jsonb.toJson(jsonMessage);
+    System.out.println(msg);
+  }
+
+
+  private String getClientAddress(SocketAddress inetSocketAddress) {
+    if (inetSocketAddress == null) {
+      return null;
+    }
+    return inetSocketAddress.host();
+  }
+
+
+  @Override
+  public void handle(RoutingContext context) {
+    // common logging data
+    long timestamp = System.currentTimeMillis();
+    String remoteClient = getClientAddress(context.request().remoteAddress());
+    HttpMethod method = context.request().method();
+    String uri = context.request().uri();
+    HttpVersion version = context.request().version();
+
+    context.addBodyEndHandler(v -> log(context, timestamp, remoteClient, version, method, uri));
+
+    context.next();
+
+  }
+
+}


### PR DESCRIPTION
Output looks like 

`{"date":"Tue, 17 Dec 2019 15:31:03 GMT","method":"GET","uri":"/api/custom-policies/v1.0/facts","http_version":"HTTP/1.1","status":401,"content_length":0,"duration":83,"user_agent":"curl/7.54.0","remote":"0:0:0:0:0:0:0:1"}
`

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>