### PR TITLE
CPOL-32 Remove customerid from urls

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,21 +35,21 @@ mvn compile quarkus:dev
 .NOTE
 The backend requires a valid `x-rh-identity` to be supplied on calls.
 For testing purposes you can take the one that is stored in
-link:src/test/resources/rhid.txt
+link:src/test/resources/rhid.txt It has accountId = '1234' set.
 
 
 == List existing policies
 
 [source,shell]
 ----
-curl  -Hx-rh-identity:`cat src/test/resources/rhid.txt` http://localhost:8080/api/custom-policies/v1.0/policies/<id> # id = 1 or 2
+curl  -Hx-rh-identity:`cat src/test/resources/rhid.txt` http://localhost:8080/api/custom-policies/v1.0/policies
 ----
 
 
 == List fact keys (for the UI)
 [source,shell]
 ----
-curl  -Hx-rh-identity:`cat src/test/resources/rhid.txt` http://localhost:8080//api/custom-policies/v1.0/facts
+curl  -Hx-rh-identity:`cat src/test/resources/rhid.txt` http://localhost:8080/api/custom-policies/v1.0/facts
 ----
 
 == OpenAPI Endpoint / Swagger-UI

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
@@ -50,7 +50,7 @@ import javax.ws.rs.ext.Provider;
 public class IncomingRequestFilter implements ContainerRequestFilter {
 
   @Inject
-  CPPrincipalProducer producer;
+  RhIdPrincipalProducer producer;
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
@@ -66,10 +66,11 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
     Optional<XRhIdentity> xrhid = HeaderHelper.getRhIdFromString(xrhid_header);
     if (xrhid.isPresent()) {
       // header was good, so now create the security context
-      SecurityContext sctx = new CPSecurityContext(xrhid.get());
+      XRhIdentity rhIdentity = xrhid.get();
+      SecurityContext sctx = new RhIdSecurityContext(rhIdentity);
       requestContext.setSecurityContext(sctx);
       // And make the principal available for injection
-      producer.setPrincipal(sctx.getUserPrincipal());
+      producer.setPrincipal((RhIdPrincipal) sctx.getUserPrincipal());
     } else {
       // Header was present, but not correct
       requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdPrincipal.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdPrincipal.java
@@ -23,17 +23,26 @@ import javax.security.auth.Subject;
  * Simple implementation of {@link Principal}
  * @author hrupp
  */
-public class CPPrincipal implements Principal {
+public class RhIdPrincipal implements Principal {
 
   private String name;
+  private String account;
 
-  public CPPrincipal(String name) {
+  public RhIdPrincipal() {
+  }
+
+  public RhIdPrincipal(String name, String account) {
     this.name = name;
+    this.account = account;
   }
 
   @Override
   public String getName() {
     return name;
+  }
+
+  public String getAccount() {
+    return account;
   }
 
   @Override

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdPrincipalProducer.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdPrincipalProducer.java
@@ -16,7 +16,6 @@
  */
 package com.redhat.cloud.custompolicies.app.auth;
 
-import java.security.Principal;
 import javax.annotation.Priority;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Alternative;
@@ -29,17 +28,17 @@ import javax.enterprise.inject.Produces;
 @Priority(1)
 @Alternative
 @RequestScoped
-public class CPPrincipalProducer {
+public class RhIdPrincipalProducer {
 
-private Principal principal;
+private RhIdPrincipal principal;
 
-  public void setPrincipal(Principal principal) {
+  public void setPrincipal(RhIdPrincipal principal) {
     this.principal = principal;
   }
 
   @RequestScoped
   @Produces
-  Principal currentPrincipal() {
+  RhIdPrincipal currentPrincipal() {
     return this.principal;
   }
 }

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdSecurityContext.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/RhIdSecurityContext.java
@@ -24,17 +24,17 @@ import javax.ws.rs.core.SecurityContext;
  * from the parsed x-rh-identity header.
  * @author hrupp
  */
-public class CPSecurityContext implements SecurityContext {
+public class RhIdSecurityContext implements SecurityContext {
 
   private XRhIdentity rhIdentity;
 
-  public CPSecurityContext(XRhIdentity rhIdentity) {
+  public RhIdSecurityContext(XRhIdentity rhIdentity) {
     this.rhIdentity = rhIdentity;
   }
 
   @Override
   public Principal getUserPrincipal() {
-    return new CPPrincipal(rhIdentity.getUsername());
+    return new RhIdPrincipal(rhIdentity.getUsername(), rhIdentity.identity.accountNumber);
   }
 
   @Override

--- a/src/main/java/com/redhat/cloud/custompolicies/app/model/Policy.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/model/Policy.java
@@ -17,9 +17,9 @@
 package com.redhat.cloud.custompolicies.app.model;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotEmpty;
@@ -49,16 +49,7 @@ public class Policy extends PanacheEntity {
   // or alternatively storing of actions as json blob
   // See CPOL-33
   public void setActions(List<Map<String, String>> actionList) {
-    System.out.println(actionList);
-    Iterator<Map<String,String>> ite = actionList.iterator();
-    actions = "";
-    while (ite.hasNext()) {
-      Map<String,String> map = ite.next();
-      actions = actions + map.get("type");
-      if (ite.hasNext()) {
-        actions = actions + ", ";
-      }
-    }
+    actions = actionList.stream().map(m -> m.get("type")).collect(Collectors.joining(", "));
   }
 
   public static List<Policy> listPoliciesForCustomer(String customer) {

--- a/src/main/java/com/redhat/cloud/custompolicies/app/model/Policy.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/model/Policy.java
@@ -17,7 +17,9 @@
 package com.redhat.cloud.custompolicies.app.model;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotEmpty;
@@ -28,8 +30,6 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 public class Policy extends PanacheEntity {
-  @NotNull
-  @NotEmpty
   public String customerid;
 
   @NotNull
@@ -43,6 +43,23 @@ public class Policy extends PanacheEntity {
   @NotNull
   public String conditions;
   public String actions;
+
+  // De-serialise the array form of actions coming from the UI
+  // this needs more work with some more typesafe translations
+  // or alternatively storing of actions as json blob
+  // See CPOL-33
+  public void setActions(List<Map<String, String>> actionList) {
+    System.out.println(actionList);
+    Iterator<Map<String,String>> ite = actionList.iterator();
+    actions = "";
+    while (ite.hasNext()) {
+      Map<String,String> map = ite.next();
+      actions = actions + map.get("type");
+      if (ite.hasNext()) {
+        actions = actions + ", ";
+      }
+    }
+  }
 
   public static List<Policy> listPoliciesForCustomer(String customer) {
     return find("customerid", customer).list();

--- a/src/main/java/com/redhat/cloud/custompolicies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/rest/PolicyCrudService.java
@@ -107,6 +107,7 @@ public class PolicyCrudService {
     }
 
     policy.id = null;
+    policy.customerid = user.getAccount();
 
     Msg msg = new Msg(policy.conditions);
     try {

--- a/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
@@ -87,7 +87,7 @@ class RestApiTest {
   }
 
   @Test
-  void testNoAuth() {
+  void testFactsNoAuth() {
     given()
         .when().get(API_BASE + "/facts")
         .then()
@@ -117,7 +117,7 @@ class RestApiTest {
   void testGetPolicies() {
     given()
         .header(authHeader)
-        .when().get(API_BASE + "/policies/1")
+        .when().get(API_BASE + "/policies/")
         .then()
         .statusCode(200)
         .body(containsString("2nd policy"));
@@ -126,10 +126,9 @@ class RestApiTest {
   @Test
   void testGetPoliciesForUnknownAccount() {
     given()
-        .header(authHeader)
-        .when().get(API_BASE + "/policies/3")
+        .when().get(API_BASE + "/policies/")
         .then()
-        .statusCode(404);
+        .statusCode(401);
   }
 
   @Test
@@ -137,7 +136,7 @@ class RestApiTest {
     JsonPath jsonPath =
     given()
         .header(authHeader)
-        .when().get(API_BASE + "/policies/1/policy/1")
+        .when().get(API_BASE + "/policies/1")
         .then()
         .statusCode(200)
         .body(containsString("1st policy"))
@@ -153,7 +152,7 @@ class RestApiTest {
   void testGetOneBadPolicy() {
     given()
         .header(authHeader)
-        .when().get(API_BASE + "/policies/1/policy/15")
+        .when().get(API_BASE + "/policies/15")
         .then()
         .statusCode(404);
   }
@@ -161,7 +160,6 @@ class RestApiTest {
   @Test
   void testOpenApiEndpoint() {
     given()
-        .header(authHeader)
         .header("Accept",ContentType.JSON)
         .when()
         .get(API_BASE + "/openapi.json")

--- a/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 import static io.restassured.RestAssured.given;
 
-import com.redhat.cloud.custompolicies.app.model.Policy;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
@@ -142,7 +141,7 @@ class RestApiTest {
         .body(containsString("1st policy"))
         .extract().jsonPath();
 
-    Policy policy = jsonPath.getObject("",Policy.class);
+    TestPolicy policy = jsonPath.getObject("", TestPolicy.class);
     Assert.assertEquals("Action does not match", "EMAIL roadrunner@acme.org", policy.actions);
     Assert.assertEquals("Conditions do not match", "\"cores\" == 1", policy.conditions);
     Assert.assertTrue("Policy is not enabled", policy.isEnabled);

--- a/src/test/java/com/redhat/cloud/custompolicies/app/TestPolicy.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/TestPolicy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.custompolicies.app;
+
+import javax.persistence.Column;
+
+/**
+ * Stripped down policy object for testing purposes.
+ * @author hrupp
+ */
+public class TestPolicy {
+
+  public long id;
+  public String customerid;
+
+  public String name;
+  public String description;
+  @Column(name = "is_enabled")
+  public boolean isEnabled;
+
+  public String conditions;
+  public String actions;
+
+}

--- a/src/test/sql/dbinit.sql
+++ b/src/test/sql/dbinit.sql
@@ -5,7 +5,8 @@ insert into fact VALUES (1, 'cpu','STRING');
 insert into fact VALUES (2, 'cores','INT');
 insert into fact VALUES (3, 'rhelversion','STRING');
 
-create table policy (id integer, customerid varchar not null,
+create table policy (id integer,
+                     customerid varchar not null,
                      name varchar not null ,
                      description varchar,
                      is_enabled boolean not null default false,
@@ -16,11 +17,11 @@ alter table policy ADD PRIMARY KEY (customerid,id);
 create unique index pol_cus_nam_idx on policy (customerid,name); -- TODO does this make the name unique per customer (?)
 
 
-insert into policy values (1, '1', '1st policy', 'Just a test', true, '"cores" == 1','EMAIL roadrunner@acme.org');
-insert into policy values (2, '1', '2nd policy', 'Another test', false, '"cpu" != "intel"','HOOK http://localhost:8080');
-insert into policy values (3, '1', '3rd policy', 'Another test', true, '"rhelversion" >= "8" OR "cores" == 5','EMAIL toor@root.org');
-insert into policy values (4, '2', '4th policy', 'Test for account2', true, '"cores" > 4','SLACK slack://foo.slack-com/#channel');
-insert into policy values (5, '1', 'Detect Nice box', 'Test for os and arch', true, '"os_version" == "7.5" AND "arch" == "x86_64"', 'NOTIFY; EMAIL foo@acme.org');
+insert into policy values (1, '1234', '1st policy', 'Just a test', true, '"cores" == 1','EMAIL roadrunner@acme.org');
+insert into policy values (2, '1234', '2nd policy', 'Another test', false, '"cpu" != "intel"','HOOK http://localhost:8080');
+insert into policy values (3, '1234', '3rd policy', 'Another test', true, '"rhelversion" >= "8" OR "cores" == 5','EMAIL toor@root.org');
+insert into policy values (4, '1234', '4th policy', 'Test for account2', true, '"cores" > 4','SLACK slack://foo.slack-com/#channel');
+insert into policy values (5, '1234', 'Detect Nice box', 'Test for os and arch', true, '"os_version" == "7.5" AND "arch" == "x86_64"', 'NOTIFY; EMAIL foo@acme.org');
 
 -- create a sequence for hibernate id generator. Must start with a number higher than the id values
 -- of above tables


### PR DESCRIPTION
Customeids in urls was an early stop-gap that allowed to select policy sets for different users.
Now that the id is supplied via x-rh-identity header, we can remove it.

https://issues.redhat.com/browse/CPOL-32

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

@zsadeh