### PR TITLE
Actually send the policy to the engine when it is to be stored.

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/VerifyEngine.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/VerifyEngine.java
@@ -37,11 +37,18 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
                   priority = 50)
 public interface VerifyEngine {
 
+  /**
+   * Store and/or verify the FullTrigger, which is a wrapped Policy.
+   * @param trigger Policy wrapped in a data structure, the engine expects
+   * @param isDryRun If true, the engine will only verify the Policy, but not store it
+   * @param customerId Id of the customer this policy belongs to.
+   * @return A message with verification/store results.
+   */
   @POST
   @Consumes("application/json")
   @Produces("application/json")
-  Msg verify(FullTrigger trigger,
-             @QueryParam("dry") boolean isDryRun,
-             @HeaderParam("Hawkular-Tenant" ) String customerId
+  Msg store(FullTrigger trigger,
+            @QueryParam("dry") boolean isDryRun,
+            @HeaderParam("Hawkular-Tenant" ) String customerId
   );
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ quarkus.flyway.sql-migration-prefix=V
 
 # our engine backend for verification of policies
 engine/mp-rest/url=http://localhost:8083
+# If set to true skips calling the engine for policy verification and policy storage
+engine.skip=false
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/api/custom-policies/v1.0/openapi.json

--- a/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/RestApiTest.java
@@ -65,14 +65,14 @@ class RestApiTest {
     // set up mock engine
     mockServer.start();
     System.err.println("Mock engine at http://" + mockServer.getContainerIpAddress() + ":" + mockServer.getServerPort());
-    new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
+    MockServerClient mockServerClient = new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort());
+    mockServerClient
         .when(request()
             .withPath("/hawkular/alerts/triggers/trigger")
-            .withQueryStringParameter("dry","true")
             .withHeader("Hawkular-Tenant","1234")
         )
         .respond(response()
-            .withStatusCode(201)
+            .withStatusCode(200)
             .withHeader("Content-Type","application/json")
             .withBody("{ \"msg\" : \"ok\" }")
         );
@@ -177,7 +177,7 @@ class RestApiTest {
   void storeNewPolicy() {
     TestPolicy tp = new TestPolicy();
     tp.actions = "EMAIL roadrunner@acme.org";
-    tp.conditions = "\"cores\" == 2";
+    tp.conditions = "cores = 2";
     tp.name = "test1";
 
     Headers headers =


### PR DESCRIPTION
Also introduces a flag to skip the engine calls.
  Mostly meant for local development.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>