### PR TITLE
Filter out calls to health and metrics in access log.

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/JaxRsApplication.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/JaxRsApplication.java
@@ -22,6 +22,7 @@ import io.vertx.ext.web.RoutingContext;
 import javax.enterprise.event.Observes;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Set the base path for the application
@@ -31,9 +32,12 @@ import javax.ws.rs.core.Application;
 @ApplicationPath("/api/custom-policies/v1.0")
 public class JaxRsApplication extends Application {
 
+  @ConfigProperty(name = "accesslog.filter.health", defaultValue = "true")
+  boolean filterHealth;
+
   // Produce access log
   void observeRouter(@Observes Router router) {
-    Handler<RoutingContext> handler = new JsonAccessLoggerHandler();
+    Handler<RoutingContext> handler = new JsonAccessLoggerHandler(filterHealth);
     router.route().order(-1000).handler(handler);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,6 @@ engine.skip=false
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/api/custom-policies/v1.0/openapi.json
+
+# Filter health calls (hc, metrics) from access log that were successful
+accesslog.filter.health=true


### PR DESCRIPTION
They happen very often in Kube and don't provide real value (in the logs) when they are successful.
If they do not return a 200 status, they are still logged. A property `accesslog.filter.health` can be set to false to prevent that filtering.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>