### PR TITLE
CPOL-61 Reduce the path in the openapi document to the last url segment

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/openapi/OAPathModifier.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/openapi/OAPathModifier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.custompolicies.app.openapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+
+/**
+ * Modify the path in the openapi document to not
+ * have the prefix, which is already in the
+ * servers part of the document.
+ * @author hrupp
+ */
+public class OAPathModifier implements OASFilter {
+
+  @Override
+  public void filterOpenAPI(OpenAPI openAPI) {
+    Paths paths = openAPI.getPaths();
+    Set<String> keySet = paths.getPathItems().keySet();
+    Map<String,PathItem> replacementItems = new HashMap<>();
+    for (String key : keySet) {
+      PathItem p = paths.getPathItem(key);
+      String mangledName = mangleName(key);
+      replacementItems.put(mangledName,p);
+    }
+    paths.setPathItems(replacementItems);
+  }
+
+  private String mangleName(String key) {
+    return key.replace("/api/custom-policies/v1.0","");
+  }
+}

--- a/src/main/resources/META-INF/openapi.json
+++ b/src/main/resources/META-INF/openapi.json
@@ -1,5 +1,10 @@
 {
   "openapi": "3.0.1",
+  "info" : {
+    "description": "The API for Custom-Policies",
+    "version": "1.0",
+    "title": "Custom-Policies"
+  },
   "security": [
     {
       "Basic_auth": []

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ engine.skip=false
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/api/custom-policies/v1.0/openapi.json
+mp.openapi.filter=com.redhat.cloud.custompolicies.app.openapi.OAPathModifier
 
 # Filter health calls (hc, metrics) from access log that were successful
 accesslog.filter.health=true


### PR DESCRIPTION
This removes the `/api/custom-policies/v1.0` from the paths entries so that the output now looks like

```
security:
- Basic_auth: []
paths:
  /facts:
    get:
      summary: Retrieve a list of fact (keys) along with their data types
 
```

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

cc @zsadeh