### PR TITLE
CPOL-85 Redirect /api/../v1/ to /api/../v1.0/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-web</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/com/redhat/cloud/custompolicies/RouteRedirector.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/RouteRedirector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.custompolicies;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Redirect routes with only the major version
+ * to major.minor ones.
+ * @author hrupp
+ */
+@SuppressWarnings("unused")
+public class RouteRedirector {
+
+  private static final String API_CUSTOM_POLICIES_V_1 = "/api/custom-policies/v1/";
+  private static final String API_CUSTOM_POLICIES_V_1_0 = "/api/custom-policies/v1.0/";
+
+  /**
+   * If the requested route is the one with major version only,
+   * send a 307 "Moved temporarily" with the location of the version
+   * with major.minor.
+   * See https://tools.ietf.org/html/rfc7231#section-6.4.7
+   * Using a 308 code "Moved permanently" would make sense, but
+   * it is not clear how much this code is supported in the wild.
+   * @param rc RoutingContext from vert.x
+   */
+  @RouteFilter(400)
+  void myRedirector(RoutingContext rc) {
+    if (rc.normalisedPath().startsWith(API_CUSTOM_POLICIES_V_1)) {
+      String remain = rc.normalisedPath().substring(API_CUSTOM_POLICIES_V_1.length());
+      rc.response().putHeader("Location", API_CUSTOM_POLICIES_V_1_0 +remain);
+      rc.fail(307);
+    }
+    rc.next();
+  }
+}


### PR DESCRIPTION
Note that curl does not automatically follow the redirect and needs option `-L`:

```
$ curl -i -L  -Hx-rh-identity:`cat src/test/resources/rhid.txt` http://localhost:8080/api/custom-policies/v1/policies
HTTP/1.1 307 Temporary Redirect
Location: /api/custom-policies/v1.0/policies
content-length: 0

HTTP/1.1 200 OK
TotalCount: 1
Content-Length: 240
ETag: "14482333"
Content-Type: application/json

[{"id":101,"actions":"EMAIL toor@root.org","conditions":"rhelversion >= 8 OR cores = 5","description":"Another test","isEnabled":true,"mtime":"2020-01-24 12:19:56.718","name":"3rd policy","triggerId":"09875330-a547-4fb5-be70-0a544b6e2874"}]

```
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

cc @zsadeh