### PR TITLE
Shorten metric names. Prefix path is not needed.

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/rest/PolicyCrudService.java
@@ -69,7 +69,7 @@ import org.hibernate.exception.ConstraintViolationException;
 @Path("/policies")
 @Produces("application/json")
 @Consumes("application/json")
-@Timed
+@Timed(absolute = true, name="PolicyService")
 @RequestScoped
 public class PolicyCrudService {
 


### PR DESCRIPTION
Now:

```
# TYPE application_PolicyCrudService_getPoliciesForCustomer_min_seconds gauge
application_PolicyCrudService_getPoliciesForCustomer_min_seconds 0.016811467
# TYPE application_PolicyCrudService_getPoliciesForCustomer_max_seconds gauge
application_PolicyCrudService_getPoliciesForCustomer_max_seconds 0.305149386
# TYPE application_PolicyCrudService_getPoliciesForCustomer_mean_seconds gauge
application_PolicyCrudService_getPoliciesForCustomer_mean_seconds 0.08556680147861713
```



Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>