### PR TITLE
CPOL-107 If user requests openapi.json, then send json.

### DIFF
--- a/src/main/java/com/redhat/cloud/custompolicies/app/openapi/OASAcceptHeaderMangler.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/openapi/OASAcceptHeaderMangler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.custompolicies.app.openapi;
+
+import io.quarkus.vertx.web.RouteFilter;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Change the accpet header if needed for Openapi requests
+ * @author hrupp
+ */
+public class OASAcceptHeaderMangler {
+
+    /*
+     * CPOL-107
+     * Default return format for openapi is .yml
+     * If the user requests 'openapi.json', the user assumes
+     * that a JSON format is returned. Unfortunately does Quarkus not
+     * honor the '.json' suffix but either requires a correct Accept
+     * header or the use of a query parameter.
+     *
+     * We now look at the path and if it ends in .json, replace the
+     * existing Accept heder with one that requests Json format.
+     */
+    @RouteFilter(401)
+    void oasAcceptHeaderMangler(RoutingContext rc) {
+        if (rc.normalisedPath().endsWith("openapi.json")) {
+            rc.request().headers().remove("Accept");
+            rc.request().headers().add("Accept","application/json");
+        }
+        rc.next();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

```
$ curl -i  http://localhost:8080/api/custom-policies/v1.0/openapi.json 
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET, HEAD, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Max-Age: 86400
Content-Type: application/json;charset=UTF-8
content-length: 15066

{
  "openapi" : "3.0.1",
  "info" : {
    "title" : "Custom-Policies",
    "description" : "The API for Custom-Policies",
    "version" : "1.0"
  },
  "servers" : [ {

```